### PR TITLE
Feature/more strict properties

### DIFF
--- a/lib/src/main/java/me/aartikov/lib/data_binding/Command.kt
+++ b/lib/src/main/java/me/aartikov/lib/data_binding/Command.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.channels.Channel
 class Command<T> internal constructor() {
     private val channel = Channel<T>(Channel.UNLIMITED)
 
-    fun send(command: T) {
+    internal fun sendInternal(command: T) {
         channel.offer(command)
     }
 
@@ -14,4 +14,4 @@ class Command<T> internal constructor() {
     }
 }
 
-fun <T> command() = Command<T>()
+fun <T> PropertyHost.command() = Command<T>()

--- a/lib/src/main/java/me/aartikov/lib/data_binding/PropertyHost.kt
+++ b/lib/src/main/java/me/aartikov/lib/data_binding/PropertyHost.kt
@@ -4,4 +4,8 @@ import kotlinx.coroutines.CoroutineScope
 
 interface PropertyHost {
     val propertyHostScope: CoroutineScope
+
+    fun <T> Command<T>.send(command: T) {
+        sendInternal(command)
+    }
 }

--- a/lib/src/main/java/me/aartikov/lib/data_binding/State.kt
+++ b/lib/src/main/java/me/aartikov/lib/data_binding/State.kt
@@ -35,7 +35,7 @@ class MutableStateDelegate<T> internal constructor(
     }
 }
 
-fun <T> state(initialValue: T): MutableStateDelegate<T> {
+fun <T> PropertyHost.state(initialValue: T): MutableStateDelegate<T> {
     return MutableStateDelegate(MutableStateFlow(initialValue))
 }
 
@@ -49,10 +49,10 @@ fun <T> PropertyHost.stateFromFlow(initialValue: T, flow: Flow<T>): StateDelegat
     return StateDelegate(resultFlow)
 }
 
-fun <T> stateFromFlow(stateFlow: StateFlow<T>): StateDelegate<T> {
+fun <T> PropertyHost.stateFromFlow(stateFlow: StateFlow<T>): StateDelegate<T> {
     return StateDelegate(stateFlow)
 }
 
-fun <T> stateFromFlow(mutableStateFlow: MutableStateFlow<T>): MutableStateDelegate<T> {
+fun <T> PropertyHost.stateFromFlow(mutableStateFlow: MutableStateFlow<T>): MutableStateDelegate<T> {
     return MutableStateDelegate(mutableStateFlow)
 }

--- a/lib/src/test/java/me/aartikov/lib/data_binding/CommandTest.kt
+++ b/lib/src/test/java/me/aartikov/lib/data_binding/CommandTest.kt
@@ -11,13 +11,19 @@ class CommandTest {
     val dispatchersTestRule = DispatchersTestRule()
 
     @Test
-    fun `doesn't receive command when not started`()  {
+    fun `doesn't receive command when not started`() {
         val propertyObserver = TestPropertyObserver()
-        val command = command<Int>()
+        val propertyHost = object : TestPropertyHost() {
+            val command = command<Int>()
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { command bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost.command bind { values.add(it) }
+        }
 
-        command.send(0)
+        with(propertyHost) {
+            command.send(0)
+        }
 
         assertEquals(emptyList<Int>(), values)
     }
@@ -25,16 +31,26 @@ class CommandTest {
     @Test
     fun `receives command when started`() {
         val propertyObserver = TestPropertyObserver()
-        val command = command<Int>()
+        val propertyHost = object : TestPropertyHost() {
+            val command = command<Int>()
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { command bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost.command bind { values.add(it) }
+        }
 
         propertyObserver.propertyObserverLifecycleOwner.onStart()
-        command.send(0)
+        with(propertyHost) {
+            command.send(0)
+        }
         propertyObserver.propertyObserverLifecycleOwner.onResume()
-        command.send(1)
+        with(propertyHost) {
+            propertyHost.command.send(1)
+        }
         propertyObserver.propertyObserverLifecycleOwner.onPause()
-        command.send(2)
+        with(propertyHost) {
+            propertyHost.command.send(2)
+        }
 
         assertEquals(listOf(0, 1, 2), values)
     }
@@ -42,12 +58,18 @@ class CommandTest {
     @Test
     fun `doesn't receive command when stopped`() {
         val propertyObserver = TestPropertyObserver()
-        val command = command<Int>()
+        val propertyHost = object : TestPropertyHost() {
+            val command = command<Int>()
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { command bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost.command bind { values.add(it) }
+        }
 
         propertyObserver.propertyObserverLifecycleOwner.onStop()
-        command.send(0)
+        with(propertyHost) {
+            command.send(0)
+        }
 
         assertEquals(emptyList<Int>(), values)
     }
@@ -55,12 +77,18 @@ class CommandTest {
     @Test
     fun `saves commands when stopped`() {
         val propertyObserver = TestPropertyObserver()
-        val command = command<Int>()
+        val propertyHost = object : TestPropertyHost() {
+            val command = command<Int>()
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { command bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost.command bind { values.add(it) }
+        }
 
         propertyObserver.propertyObserverLifecycleOwner.onStop()
-        repeat(3) { command.send(0) }
+        with(propertyHost) {
+            repeat(3) { command.send(0) }
+        }
         propertyObserver.propertyObserverLifecycleOwner.onStart()
 
         assertEquals(listOf(0, 0, 0), values)
@@ -69,11 +97,17 @@ class CommandTest {
     @Test
     fun `saves commands before starting`() {
         val propertyObserver = TestPropertyObserver()
-        val command = command<Int>()
+        val propertyHost = object : TestPropertyHost() {
+            val command = command<Int>()
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { command bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost.command bind { values.add(it) }
+        }
 
-        repeat(3) { command.send(0) }
+        with(propertyHost) {
+            repeat(3) { command.send(0) }
+        }
         propertyObserver.propertyObserverLifecycleOwner.onStart()
 
         assertEquals(listOf(0, 0, 0), values)

--- a/lib/src/test/java/me/aartikov/lib/data_binding/StateTest.kt
+++ b/lib/src/test/java/me/aartikov/lib/data_binding/StateTest.kt
@@ -13,11 +13,15 @@ class StateTest {
     @Test
     fun `receives nothing when not started`() {
         val propertyObserver = TestPropertyObserver()
-        val state = state(0)
+        val propertyHost = object : TestPropertyHost() {
+            var state by state(0)
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { state bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost::state bind { values.add(it) }
+        }
 
-        state.value++
+        propertyHost.state++
 
         assertEquals(emptyList<Int>(), values)
     }
@@ -25,16 +29,20 @@ class StateTest {
     @Test
     fun `receives values when started`() {
         val propertyObserver = TestPropertyObserver()
-        val state = state(0)
+        val propertyHost = object : TestPropertyHost() {
+            var state by state(0)
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { state bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost::state bind { values.add(it) }
+        }
 
         propertyObserver.propertyObserverLifecycleOwner.onStart()
-        state.value++
+        propertyHost.state++
         propertyObserver.propertyObserverLifecycleOwner.onResume()
-        state.value++
+        propertyHost.state++
         propertyObserver.propertyObserverLifecycleOwner.onPause()
-        state.value++
+        propertyHost.state++
 
         assertEquals(listOf(0, 1, 2, 3), values)
     }
@@ -42,12 +50,16 @@ class StateTest {
     @Test
     fun `receives only last state when restarted`() {
         val propertyObserver = TestPropertyObserver()
-        val state = state(0)
+        val propertyHost = object : TestPropertyHost() {
+            var state by state(0)
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { state bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost::state bind { values.add(it) }
+        }
 
         propertyObserver.propertyObserverLifecycleOwner.onStop()
-        repeat(3) { state.value++ }
+        repeat(3) { propertyHost.state++ }
         propertyObserver.propertyObserverLifecycleOwner.onStart()
 
         assertEquals(listOf(3), values)
@@ -56,14 +68,18 @@ class StateTest {
     @Test
     fun `receives nothing when stopped`() {
         val propertyObserver = TestPropertyObserver()
-        val state = state(0)
+        val propertyHost = object : TestPropertyHost() {
+            var state by state(0)
+        }
         val values = mutableListOf<Int>()
-        with(propertyObserver) { state bind { values.add(it) } }
+        with(propertyObserver) {
+            propertyHost::state bind { values.add(it) }
+        }
 
         propertyObserver.propertyObserverLifecycleOwner.onStart()
-        state.value++
+        propertyHost.state++
         propertyObserver.propertyObserverLifecycleOwner.onStop()
-        state.value++
+        propertyHost.state++
 
         assertEquals(listOf(0, 1), values)
     }


### PR DESCRIPTION
Ограничил использование state и command. Предполагается, что они будут использоваться только во ViewModel (реализующей PropertyHost)