### PR TITLE
Refactor loading. Two core methods for Loading: attach and load

### DIFF
--- a/loading/src/main/java/me/aartikov/lib/loading/paged/internal/PagedLoadingEffectHandler.kt
+++ b/loading/src/main/java/me/aartikov/lib/loading/paged/internal/PagedLoadingEffectHandler.kt
@@ -29,13 +29,13 @@ internal class PagedLoadingEffectHandler<T : Any>(private val loader: PagedLoade
             try {
                 val data = loader.loadFirstPage(fresh)
                 if (data.isEmpty()) {
-                    actionConsumer(Action.EmptyPage)
+                    actionConsumer(Action.EmptyPageLoaded)
                 } else {
-                    actionConsumer(Action.NewPage(data))
+                    actionConsumer(Action.NewPageLoaded(data))
                 }
             } catch (e: Exception) {
                 if (e !is CancellationException) {
-                    actionConsumer(Action.Error(e))
+                    actionConsumer(Action.LoadingError(e))
                 }
             }
         }
@@ -50,13 +50,13 @@ internal class PagedLoadingEffectHandler<T : Any>(private val loader: PagedLoade
             try {
                 val data = loader.loadNextPage(pagingInfo)
                 if (data.isEmpty()) {
-                    actionConsumer(Action.EmptyPage)
+                    actionConsumer(Action.EmptyPageLoaded)
                 } else {
-                    actionConsumer(Action.NewPage(data))
+                    actionConsumer(Action.NewPageLoaded(data))
                 }
             } catch (e: Exception) {
                 if (e !is CancellationException) {
-                    actionConsumer(Action.Error(e))
+                    actionConsumer(Action.LoadingError(e))
                 }
             }
         }

--- a/loading/src/main/java/me/aartikov/lib/loading/simple/Loading.kt
+++ b/loading/src/main/java/me/aartikov/lib/loading/simple/Loading.kt
@@ -3,7 +3,6 @@ package me.aartikov.lib.loading.simple
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
 
 interface Loading<T : Any> {
 
@@ -22,20 +21,17 @@ interface Loading<T : Any> {
 
     val eventFlow: Flow<Event>
 
-    suspend fun start(fresh: Boolean = true)
+    fun attach(scope: CoroutineScope): Job
 
-    fun refresh()
+    fun load(fresh: Boolean, dropData: Boolean = false)
 
-    fun restart(fresh: Boolean = true)
 }
+
+fun <T : Any> Loading<T>.refresh() = load(fresh = true, dropData = false)
+
+fun <T : Any> Loading<T>.restart(fresh: Boolean = true) = load(fresh, dropData = true)
 
 val <T : Any> Loading<T>.state: Loading.State<T> get() = stateFlow.value
-
-fun <T : Any> Loading<T>.startIn(scope: CoroutineScope, fresh: Boolean = true): Job {
-    return scope.launch {
-        start(fresh)
-    }
-}
 
 fun <T : Any> Loading<T>.handleErrors(
     scope: CoroutineScope,

--- a/loading/src/main/java/me/aartikov/lib/loading/simple/internal/LoadingImpl.kt
+++ b/loading/src/main/java/me/aartikov/lib/loading/simple/internal/LoadingImpl.kt
@@ -1,5 +1,7 @@
 package me.aartikov.lib.loading.simple.internal
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
@@ -40,21 +42,21 @@ internal class LoadingImpl<T : Any>(
     override val eventFlow: Flow<Event>
         get() = mutableEventFlow
 
-    override suspend fun start(fresh: Boolean) = coroutineScope {
-        launch {
-            loop.stateFlow.collect {
-                mutableStateFlow.value = it.toPublicState()
+    override fun attach(scope: CoroutineScope): Job = scope.launch {
+        coroutineScope {
+            launch {
+                loop.stateFlow.collect {
+                    mutableStateFlow.value = it.toPublicState()
+                }
+            }
+
+            launch {
+                loop.start()
             }
         }
-        loop.dispatch(Action.Load(fresh))
-        loop.start()
     }
 
-    override fun refresh() {
-        loop.dispatch(Action.Refresh)
-    }
-
-    override fun restart(fresh: Boolean) {
-        loop.dispatch(Action.Restart(fresh))
+    override fun load(fresh: Boolean, dropData: Boolean) {
+        loop.dispatch(Action.Load(fresh, dropData))
     }
 }

--- a/loading/src/main/java/me/aartikov/lib/loading/simple/internal/LoadingLoop.kt
+++ b/loading/src/main/java/me/aartikov/lib/loading/simple/internal/LoadingLoop.kt
@@ -12,9 +12,7 @@ internal sealed class State<out T> {
 }
 
 internal sealed class Action<out T> {
-    data class Load(val fresh: Boolean) : Action<Nothing>()
-    object Refresh : Action<Nothing>()
-    data class Restart(val fresh: Boolean) : Action<Nothing>()
+    data class Load(val fresh: Boolean, val dropData: Boolean) : Action<Nothing>()
 
     data class DataLoaded<T>(val data: T) : Action<T>()
     object EmptyDataLoaded : Action<Nothing>()
@@ -36,38 +34,28 @@ internal class LoadingReducer<T> : Reducer<State<T>, Action<T>, Effect> {
     override fun reduce(state: State<T>, action: Action<T>): Next<State<T>, Effect> = when (action) {
 
         is Action.Load -> {
-            when (state) {
-                is State.Empty -> next(
+            if (action.dropData) {
+                next(
                     State.Loading,
                     Effect.Load(action.fresh)
                 )
-                else -> nothing()
+            } else {
+                when (state) {
+                    is State.Empty -> next(
+                        State.Loading,
+                        Effect.Load(action.fresh)
+                    )
+                    is State.Error -> next(
+                        State.Loading,
+                        Effect.Load(action.fresh)
+                    )
+                    is State.Data -> next(
+                        State.Refresh(data = state.data),
+                        Effect.Load(action.fresh)
+                    )
+                    else -> nothing()
+                }
             }
-        }
-
-        is Action.Refresh -> {
-            when (state) {
-                is State.Empty -> next(
-                    State.Loading,
-                    Effect.Load(fresh = true)
-                )
-                is State.Error -> next(
-                    State.Loading,
-                    Effect.Load(fresh = true)
-                )
-                is State.Data -> next(
-                    State.Refresh(data = state.data),
-                    Effect.Load(fresh = true)
-                )
-                else -> nothing()
-            }
-        }
-
-        is Action.Restart -> {
-            next(
-                State.Loading,
-                Effect.Load(action.fresh)
-            )
         }
 
         is Action.DataLoaded -> {

--- a/sample/src/main/java/me/aartikov/androidarchitecture/movies/ui/MoviesViewModel.kt
+++ b/sample/src/main/java/me/aartikov/androidarchitecture/movies/ui/MoviesViewModel.kt
@@ -7,7 +7,7 @@ import me.aartikov.androidarchitecture.movies.data.MoviesGateway
 import me.aartikov.androidarchitecture.movies.domain.Movie
 import me.aartikov.lib.loading.paged.PagedLoading
 import me.aartikov.lib.loading.paged.handleErrors
-import me.aartikov.lib.loading.paged.startIn
+import me.aartikov.lib.loading.paged.refresh
 import me.aartikov.lib.property.stateFromFlow
 import javax.inject.Inject
 
@@ -27,7 +27,8 @@ class MoviesViewModel @Inject constructor(
             if (error.hasData)
                 showError(error.throwable)
         }
-        moviesLoading.startIn(viewModelScope)
+        moviesLoading.attach(viewModelScope)
+        moviesLoading.refresh()
     }
 
     fun onPullToRefresh() = moviesLoading.refresh()

--- a/sample/src/main/java/me/aartikov/androidarchitecture/profile/ui/ProfileViewModel.kt
+++ b/sample/src/main/java/me/aartikov/androidarchitecture/profile/ui/ProfileViewModel.kt
@@ -6,7 +6,7 @@ import me.aartikov.androidarchitecture.base.BaseViewModel
 import me.aartikov.androidarchitecture.profile.data.ProfileGateway
 import me.aartikov.lib.loading.simple.OrdinaryLoading
 import me.aartikov.lib.loading.simple.handleErrors
-import me.aartikov.lib.loading.simple.startIn
+import me.aartikov.lib.loading.simple.refresh
 import me.aartikov.lib.property.stateFromFlow
 import javax.inject.Inject
 
@@ -25,7 +25,8 @@ class ProfileViewModel @Inject constructor(
                 showError(error.throwable)
             }
         }
-        profileLoading.startIn(viewModelScope)
+        profileLoading.attach(viewModelScope)
+        profileLoading.refresh()
     }
 
     fun onPullToRefresh() {


### PR DESCRIPTION
The problem with `startIn` method is that it attaches `Loading` to a coroutine scope and starts loading at the same time. Now this actions are separated.

`attach` - prepares `Loading` but does not initiate any loading.
`load(fresh, dropData)` - requests to load data.

`refresh`, `restart` - are just useful aliases for `load` now.